### PR TITLE
feat: handle multiple contents from playwright-mcp, remove closing workaround

### DIFF
--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -28,12 +28,6 @@ const patchClientClose = (name: string, client: Client) => {
   const originalClose = client.close.bind(client);
   client.close = async () => {
     logMcpClientClose(name);
-    // TODO: Better way to handle this case
-    // Currently, our patch doesn't handle trace output well when MCP server is closed
-    // so that we need to call browser_close tool explicitly.
-    const { tools } = await client.listTools();
-    if (tools.find(({ name }) => name === "browser_close"))
-      await client.callTool({ name: "browser_close" });
     await originalClose();
   };
 };

--- a/src/ui/mcp-tools.ts
+++ b/src/ui/mcp-tools.ts
@@ -1,5 +1,6 @@
 import { performance } from "node:perf_hooks";
 
+import { MessageContent, ToolMessage } from "@langchain/core/messages";
 import { StructuredToolInterface } from "@langchain/core/tools";
 import truncate from "cli-truncate";
 
@@ -15,7 +16,7 @@ function elapsed(start: number, end: number): string {
   return `${(elapsed / 1000).toFixed(2)}s`;
 }
 
-export const logMcpTools = (tools: StructuredToolInterface[]) => {
+export const logMcpTools = (tools: Tool[]) => {
   logger.info(
     { tools: tools.map((tool) => tool.name).join(", ") },
     `Loaded MCP tools`,
@@ -29,15 +30,29 @@ export const logMcpCall = async (
 ) => {
   logger.info({ input: args[0] }, `MCP start: ${tool.name}`);
   const start = performance.now();
-  const result = await invoke(...args);
+  const result = (await invoke(...args)) as ToolMessage;
   const end = performance.now();
   const duration = elapsed(start, end);
-  // @ts-expect-error The caller doesn't know the type neither.
-  const content = result?.content as string;
+  const content = concatTextContent(result.content);
   const truncated = truncate(content, 100);
   logger.info({ content: truncated }, `MCP end:   ${tool.name} (${duration})`);
   logger.debug(`MCP end:   ${tool.name} (${duration})\n${content}`);
+  result.content = content;
   return result;
+};
+
+const concatTextContent = (content: MessageContent): string => {
+  // If the content is a string, return it directly
+  if (typeof content === "string") return content;
+
+  // If the content is array, filter only text type content and join them with new lines
+  if (Array.isArray(content))
+    return content
+      .flatMap((content) => (typeof content === "string" ? [content] : []))
+      .join("\n");
+
+  // Fallback to JSON.stringify for the other unknown types in case the type will be evolved
+  return JSON.stringify(content);
 };
 
 export const logMcpClientStdioStart = (


### PR DESCRIPTION
This commit allows aethr to handle multiple contents returned from MCP servers.

Also, we've finally found the proper way to handle closing race on @aethr/playwright-mcp so that we no more need the workaround.