### PR TITLE
fix: ollama client doesn't accept non-string tool response

### DIFF
--- a/examples/visit.test.md
+++ b/examples/visit.test.md
@@ -1,8 +1,8 @@
 # Test visit feature
 
 Follow the steps below.
-Just call browser_navigate and finish.
 
 ## Steps
 
-1. Visit https://the-internet.herokuapp.com/login
+1. Visit https://github.com/autifyhq/aethr
+2. Assert 'Aethr /ˈiːθər/' exists

--- a/src/cli/run-command.ts
+++ b/src/cli/run-command.ts
@@ -44,7 +44,7 @@ export async function runCommand(
     const fileContent = await loadTestFile(filePath);
     const input = { messages: [{ role: "user", content: fileContent }] };
 
-    const mcpTools = await createMcpTools(profile.mcpServers, {
+    const mcpTools = await createMcpTools(profile.mcpServers, model, {
       thinkTool,
       reasoning,
       tempDir,


### PR DESCRIPTION
This commit fixes #15 by just stringifying the non-string tool response like OpenAI client.