### PR TITLE
feat: add exclude option to mcpServers config

### DIFF
--- a/default.aethr.config.mjs
+++ b/default.aethr.config.mjs
@@ -9,13 +9,18 @@ export default {
             "-y",
             "@aethr/playwright-mcp@latest",
             ...["--browser", "chromium"],
-            ...["--headless"],
+            ...(process.env.CI ? ["--headless"] : []),
             ...["--user-data-dir", "${TEMP_DIR}"], // ${TEMP_DIR} is given by Aethr per run and cleared after the run
           ],
           env: {
             FORCE_COLOR: "0", // To avoid unnecessary color codes in the assertion failure message
             TRACE: "./trace.zip", // Location to store the trace file
           },
+          exclude: [
+            "browser_close",
+            "browser_take_screenshot",
+            "browser_generate_playwright_test",
+          ],
         },
       },
       runOptions: {

--- a/src/mcp/config.ts
+++ b/src/mcp/config.ts
@@ -4,6 +4,7 @@ export const StdioServerConfig = z.object({
   command: z.string(),
   args: z.array(z.string()).optional(),
   env: z.record(z.string(), z.string()).optional(),
+  exclude: z.array(z.string()).optional(),
 });
 export type StdioServerConfig = z.infer<typeof StdioServerConfig>;
 


### PR DESCRIPTION
Sometime, unnecessary tools confuse LLMs e.g. browser_close. This commit adds a config option to explicitly exclude tools at runtime.