### PR TITLE
feat: adjust for 0.0.28 of Playwright MCP

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -45,10 +45,8 @@ jobs:
         run: npm ci
       - name: Run with ${{ matrix.model }}
         run: npm run start -- run examples/login.test.md
-      - name: Extract trace.zip (to avoid double zipping)
-        if: always()
-        run: mkdir -p trace && unzip trace.zip -d trace
       - name: Sanitize model without forward slashes
+        if: always()
         id: sanitize
         run: |
           MODEL=$(echo "${{ matrix.model }}" | tr '/' '_')
@@ -58,7 +56,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: trace-${{ steps.sanitize.outputs.model }}
-          path: trace
+          path: outputs/traces
       - name: Archive logs
         if: always()
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ Makefile
 logs/
 aethr.config.mjs
 .artifacts/
+outputs/

--- a/default.aethr.config.mjs
+++ b/default.aethr.config.mjs
@@ -7,14 +7,15 @@ export default {
           command: "npx",
           args: [
             "-y",
-            "@aethr/playwright-mcp@latest",
+            "@aethr/playwright-mcp@0.0.28-patch.0",
             ...["--browser", "chromium"],
             ...(process.env.CI ? ["--headless"] : []),
-            ...["--user-data-dir", "${TEMP_DIR}"], // ${TEMP_DIR} is given by Aethr per run and cleared after the run
+            ...["--isolated", "--no-sandbox"],
+            ...["--output-dir", "./outputs"],
+            ...["--save-trace"],
           ],
           env: {
             FORCE_COLOR: "0", // To avoid unnecessary color codes in the assertion failure message
-            TRACE: "./trace.zip", // Location to store the trace file
           },
           exclude: [
             "browser_close",

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -25,7 +25,7 @@ You are a QA agent, testing a web application step-by-step. Follow these rules e
   b. Example: for "\${URL}", use "\${URL}" as-is, do not generate or guess the URL.
 
 4. ELEMENT REFERENCES
-  a. Always use the "ref" from the **latest** snapshot ("s<snapshot_id>e<element_id>").
+  a. Always use the "ref" from the **latest** snapshot ("e<element_id>").
   b. Do **not** reuse stale refs from earlier snapshots.
 
 5. ASSERTIONS


### PR DESCRIPTION
Because it now supports tracing officially, we change how to call them in the default.aethr.config.mjs as well as GitHub Actions.